### PR TITLE
Update Scaleway typo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Homepage: [Scaleway](https://www.scaleway.com/)
 
 ### Always Free
 
-- 75GB block storage (S3-compatible API)
+- 75GB object storage (S3-compatible API)
 - 50k message in the IoT Hub ([MQTT](https://en.wikipedia.org/wiki/MQTT), [REST](https://en.wikipedia.org/wiki/Representational_state_transfer), [Sigfox](https://en.wikipedia.org/wiki/Sigfox), [LoRa](https://en.wikipedia.org/wiki/LoRa))
 
 ## 8. DigitalOcean


### PR DESCRIPTION
Replace "75GB block storage" in the Always Free section for Scaleway with "75GB object storage" for accuracy.

Please see link for more details regarding free 75GB object storage (not block storage) from Scaleway:
https://www.scaleway.com/en/pricing/?tags=available,storage-objectstorage-objectstorage 