### PR TITLE
remove fly.io as per new pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ Comparing the free tier offers of the major cloud providers like AWS, Azure, GCP
 13. [OpenShift](#13-openshift)
 14. [Linode](#14-linode)
 15. [Container Hosting Service](#15-container-hosting-service)
-16. [Fly.io](#16-fly-io)
-17. [Cloudflare](#17-cloudflare)
-18. [OVH](#18-ovh)
+16. [Cloudflare](#17-cloudflare)
+17. [OVH](#18-ovh)
 
 ## 1. AWS
 

--- a/README.md
+++ b/README.md
@@ -192,17 +192,7 @@ Homepage: [Container Hosting Service](https://container-hosting.anotherwebservic
 ### Currently Free
 - Container Hosting Service [Try Open Source Container Hosting Service for free](https://container-hosting.anotherwebservice.com/)
 
-## 16. Fly.io
-
-Homepage: [Fly.io](https://fly.io/docs/about/pricing/)
-
-### Always free on all plans:
-
-- Up to 3 shared-cpu-1x 256mb VMs (Apps or Machines)
-- 3GB persistent volume storage (total)
-- 160GB outbound data transfer
-
-## 17. Cloudflare
+## 16. Cloudflare
 
 Homepage: [Cloudflare](https://www.cloudflare.com/plans/)
 
@@ -216,7 +206,7 @@ Homepage: [Cloudflare](https://www.cloudflare.com/plans/)
 - Web Application Firewall
 - Workers & Pages - serverless functions
 
-## 18. OVH
+## 17. OVH
 
 Homepage: [OVH](https://www.ovhcloud.com)
 


### PR DESCRIPTION
According to https://fly.io/docs/about/pricing/#legacy-free-allowances, fly.io is discontinuing their free allowances for new customers